### PR TITLE
feat: 添加手势通道切换与耗时记录

### DIFF
--- a/server/routes/control.py
+++ b/server/routes/control.py
@@ -192,6 +192,23 @@ async def device_info(noShot: bool = False):
         return JSONResponse({"error": str(e)}, status_code=502)
 
 
+@router.post("/api/control-mode")
+async def api_control_mode(payload: Dict[str, Any]):
+    mode = str(payload.get("mode", "")).strip().lower()
+    mapping = {
+        "wda": "wda",
+        "appium": "actions",
+        "actions": "actions",
+        "jsonwp": "jsonwp",
+        "auto": "auto",
+    }
+    if mode not in mapping:
+        return JSONResponse({"error": f"invalid mode: {mode}"}, status_code=400)
+    core.CURRENT_MODE = mapping[mode]
+    core.logger.info(f"control mode set to {core.CURRENT_MODE}")
+    return {"ok": True, "mode": mode, "current": core.CURRENT_MODE}
+
+
 @router.post("/api/tap")
 async def api_tap(payload: TapRequest):
     try:

--- a/web/index.html
+++ b/web/index.html
@@ -34,7 +34,15 @@
     <header>
       <label><input type="checkbox" id="gest-debug"/> 调试日志</label>
       <label><input type="checkbox" id="gest-dryrun"/> 仅日志（不发送）</label>
-      
+
+      <div class="row">
+        <label for="gest-channel" class="muted">通道</label>
+        <select id="gest-channel" style="padding:4px 6px;border:1px solid var(--line);border-radius:8px;background:#0f0f12;color:var(--fg)">
+          <option value="wda">WDA</option>
+          <option value="appium">Appium</option>
+        </select>
+      </div>
+
       <div class="row">
         <label for="gest-intensity" class="muted">甩动力度</label>
         <select id="gest-intensity" style="padding:4px 6px;border:1px solid var(--line);border-radius:8px;background:#0f0f12;color:var(--fg)">


### PR DESCRIPTION
## Summary
- 添加 `/api/control-mode` 接口以切换 WDA/Appium 手势通道
- 手势面板支持选择通道并记录 WebSocket 往返耗时

## Testing
- `python -m py_compile server/core.py server/routes/control.py`


------
https://chatgpt.com/codex/tasks/task_e_68b91989bbf88323ae8d4af8650d3f51