### PR TITLE
fix(server): 允许 localhost:8080 跨域访问

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -12,12 +12,11 @@ from routes.appium_proxy import router as appium_router
 
 app = FastAPI(title="WDA-Web Console", version="1.0")
 
-# CORS: open for dev; tighten in prod
+# CORS: 允许前端 http://localhost:8080 访问
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_origin_regex=r".*",  # be permissive for local dev (localhost/127.0.0.1/[::1])
-    allow_credentials=False,
+    allow_origins=["http://localhost:8080"],
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
     expose_headers=["*"],


### PR DESCRIPTION
## Summary
- allow frontend at http://localhost:8080 to access server via CORS

## Testing
- `python -m py_compile server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94c61b1d88323a58f8d6d0a7af870