### PR TITLE
feat(web): tap操作改用Appium脚本

### DIFF
--- a/web/gesture-recognizer.js
+++ b/web/gesture-recognizer.js
@@ -71,7 +71,7 @@ function setupInteractHandlers(){
 }
 function setupGestureRecognizer(){
   updatePumpPill();
-  mappingPill && (mappingPill.textContent = 'tap→/api/tap(WDA) · longPress→mobile: touchAndHold · drag(flick/drag)→mobile: dragFromToWithVelocity');
+  mappingPill && (mappingPill.textContent = 'tap→mobile: tap · longPress→mobile: touchAndHold · drag(flick/drag)→mobile: dragFromToWithVelocity');
   try{ setupInteractHandlers(); }catch(_e){}
   if (typeof interact !== 'undefined') {
     const target = canvas;

--- a/web/gesture-request.js
+++ b/web/gesture-request.js
@@ -51,12 +51,9 @@ async function mobileExec(script, args, label){
   }
 }
 async function tapAt(x,y){
-  log('tapAt', { ch:'wda', x, y });
+  log('tapAt', { ch:'appium', x, y });
   if (DRYRUN){ log('DRYRUN tap skip send'); return; }
-  await safeFetch(API + '/api/tap', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({ x, y })
-  }, '点击');
+  await mobileExec('mobile: tap', { x: Math.round(x), y: Math.round(y) }, '点击');
 }
 async function longPressAt(x,y, durationMs){
   const durMs = Math.max(200, Math.round(durationMs||600));


### PR DESCRIPTION
## Summary
- tapAt 通过 `mobile: tap` 执行，不再访问 `/api/tap`
- 更新手势映射提示为 `tap→mobile: tap`

## Testing
- `npm test` *(fail: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b97d6efe788323a6a6586bf0103004