### PR TITLE
feat: 通过 WS 获取 Appium 设置

### DIFF
--- a/server/ws_proxy_client.py
+++ b/server/ws_proxy_client.py
@@ -13,6 +13,7 @@ MESSAGE_ROUTES = {
     "device.info": {"method": "GET", "path": "/api/device-info"},
     "appium.session.create": {"method": "POST", "path": "/api/appium/create"},
     "appium.settings.apply": {"method": "POST", "path": "/api/appium/settings"},
+    "appium.settings.fetch": {"method": "GET", "path": "/api/appium/settings"},
     "discovery.devices.list": {"method": "GET", "path": "/api/discovery/devices"},
     "appium.exec.mobile": {"method": "POST", "path": "/api/appium/exec-mobile"},
     "appium.actions.execute": {"method": "POST", "path": "/api/appium/actions"},

--- a/websocket/server.py
+++ b/websocket/server.py
@@ -18,6 +18,7 @@ MESSAGE_ROUTES: Dict[str, Dict[str, Any]] = {
     "device.info": {"method": "GET", "path": "/api/device-info"},
     "appium.session.create": {"method": "POST", "path": "/api/appium/create"},
     "appium.settings.apply": {"method": "POST", "path": "/api/appium/settings"},
+    "appium.settings.fetch": {"method": "GET", "path": "/api/appium/settings"},
     "discovery.devices.list": {"method": "GET", "path": "/api/discovery/devices"},
     "appium.exec.mobile": {"method": "POST", "path": "/api/appium/exec-mobile"},
     "appium.actions.execute": {"method": "POST", "path": "/api/appium/actions"},


### PR DESCRIPTION
## Summary
- websocket 与后端代理新增 appium.settings.fetch 消息转发规则
- web-vue 将 Appium 设置读取切换为通过 websocket 发送 appium.settings.fetch
- 优化拉取 Appium 设置时的错误提示与会话失效处理

## Testing
- 未运行（仓库未提供相关自动化测试）

------
https://chatgpt.com/codex/tasks/task_e_68cd4fd481e883239d764480ec813dfc