### PR TITLE
fix: 生产环境仅使用 WebRTC 拉流

### DIFF
--- a/web-vue/src/App.vue
+++ b/web-vue/src/App.vue
@@ -160,6 +160,7 @@ import { useToastStore } from './stores/toastStore';
 const { pushToast } = useToastStore();
 const LS = safeLocalStorage;
 const isDev = import.meta.env.DEV;
+const isProd = import.meta.env.PROD;
 
 function getParam(name) {
   try {
@@ -523,6 +524,7 @@ function clampZoom(n) {
 }
 
 function readStreamMode() {
+  if (isProd) return 'webrtc';
   const raw = String(getLS('stream.mode', 'mjpeg') || 'mjpeg');
   return raw === 'webrtc' ? 'webrtc' : 'mjpeg';
 }
@@ -702,7 +704,7 @@ function applyStreamMode() {
   if (!hasAppiumSession()) {
     mjpegSrc.value = '';
     webrtcSrc.value = '';
-    if (streamMode.value !== 'mjpeg') streamMode.value = 'mjpeg';
+    if (!isProd && streamMode.value !== 'mjpeg') streamMode.value = 'mjpeg';
     updateDisplayLayout();
     return;
   }


### PR DESCRIPTION
## Summary
- 新增生产环境标识，限制读取流模式为 WebRTC
- 避免无会话时在生产环境退回 MJPEG，确保始终保持 WebRTC 模式

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd756e5884832382bb5ae183b77c07