### PR TITLE
调整手势与ffmpeg日志处理

### DIFF
--- a/server/stream_pusher.py
+++ b/server/stream_pusher.py
@@ -272,6 +272,13 @@ def _prepare_ffmpeg_log_path(udid: str, session_id: str) -> Optional[Path]:
         core.logger.exception("Failed to ensure ffmpeg log directory %s", log_dir)
         return None
 
+    for entry in list(log_dir.glob("*.log")):
+        try:
+            if entry.is_file():
+                entry.unlink()
+        except OSError:
+            core.logger.exception("Failed to remove old ffmpeg log %s", entry)
+
     safe_udid = _sanitize_for_filename(udid) or "unknown_udid"
     safe_session = _sanitize_for_filename(session_id) or "unknown_session"
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/web-vue/src/App.vue
+++ b/web-vue/src/App.vue
@@ -708,7 +708,6 @@ function appendGestLog(line) {
 function ev(type, payload) {
   const line = payload ? `${type}: ${JSON.stringify(payload)}` : type;
   appendGestLog(line);
-  try { console.log('[GEST]', line); } catch (_err) {}
 }
 
 function logDebug() {}
@@ -1352,7 +1351,7 @@ function setupGestureRecognizer() {
 
   function setupInteractHandlers() {
     if (typeof interact === 'undefined') {
-      console.warn('[GEST] interact.js not ready');
+      appendGestLog('[GEST] interact.js not ready');
       return;
     }
     try {
@@ -1466,7 +1465,8 @@ function setupGestureRecognizer() {
           clearPressTimer();
         });
     } catch (err) {
-      console.warn('[GEST] interact setup error', err);
+      const detail = err instanceof Error ? `${err.message}` : `${err}`;
+      appendGestLog(`[GEST] interact setup error: ${detail}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- 手势日志仅保留在手势日志面板显示，避免额外的控制台输出
- 新建 ffmpeg 日志前清理日志目录中的旧日志文件

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce1fcaf6048323bac335011acac943